### PR TITLE
Save initial state of location into store

### DIFF
--- a/cmd/gardena_smart_system_exporter.go
+++ b/cmd/gardena_smart_system_exporter.go
@@ -24,18 +24,18 @@ func main() {
 		WithSecretFilePath(secretFilePath).
 		Initialize()
 	if err != nil {
-		log.Fatalf("unable to initialize the api, got error:\n %v", err)
+		log.Fatalf("unable to initialize the api, got error:\n%v", err)
 	}
 
-	generator := metric.NewGenerator(*api, gatewayIP)
-	if err := generator.InitializeLocationsMetrics(); err != nil {
-		log.Fatalf("Unable to setup initial location metrics, got err:\n %v", err)
+	g := metric.NewGenerator(*api, gatewayIP)
+	if err := g.InitializeLocationsMetrics(); err != nil {
+		log.Fatalf("Unable to setup initial location metrics, got err:\n%v", err)
 	}
 
 	log.Println("Start serving metrics...")
 	go func() {
 		for {
-			generator.MonitorHealthOfEndpoints()
+			g.MonitorHealthOfEndpoints()
 			time.Sleep(time.Duration(metricInterval) * time.Second)
 		}
 	}()

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -1,0 +1,68 @@
+package state
+
+import (
+	"fmt"
+	"github.com/Christoph-Raab/gardena-smart-system-exporter/pkg/gardena"
+	"github.com/Christoph-Raab/gardena-smart-system-exporter/pkg/gardena/device"
+)
+
+type Store struct {
+	devices map[string]device.Device
+}
+
+// NewStore creates a new map[string]device.Device
+func NewStore() Store {
+	var s Store
+	s.devices = make(map[string]device.Device)
+	return s
+}
+
+// StoreDevices adds all devices for a give location state to the store
+func (s *Store) StoreDevices(location gardena.State) error {
+	devices := s.devicesFrom(location)
+	for k, v := range devices {
+		if err := s.addDevice(k, v); err != nil {
+			return fmt.Errorf("Unable to add all devices to internal store for location %s, got err\n%v", location.Data.Id, err)
+		}
+	}
+	return nil
+}
+
+// addDevice adds a given id/map of attributes to the store.
+// It uses the factory method of gardena.device to create an
+// actual device (MOWER, SENSOR, ...) from the input.
+// If a device with the given id is already in the store
+// an error is returned.
+func (s *Store) addDevice(id string, attrs map[string]any) error {
+	if s.devices[id] != nil {
+		return fmt.Errorf("device with id %s already in store", id)
+	}
+	d, err := device.Factory(attrs)
+	if err != nil {
+		return fmt.Errorf("unable to create device with device with id %s with factory, got err:\n%w", id, err)
+	}
+	s.devices[id] = d
+	return nil
+}
+
+// devicesFrom generates a map of devices by merging DEVICE, <type> and COMMON into on map of
+// attributes with the attribute name as key. The attribute value is either a str or a float.
+// Those devices are collected in a map with the device ID as key.
+func (s *Store) devicesFrom(locationData gardena.State) map[string]map[string]any {
+	devices := make(map[string]map[string]any)
+	for _, d := range locationData.Included {
+		m := devices[d.Id]
+		if m == nil {
+			m = make(map[string]any)
+		}
+		m[device.AttrId] = d.Id
+		if d.Type != device.CommonType && d.Type != device.Type {
+			m[device.AttrType] = d.Type
+		}
+		for k, v := range d.Attributes {
+			m[k] = v.Value
+		}
+		devices[d.Id] = m
+	}
+	return devices
+}

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -1,0 +1,92 @@
+package state
+
+import (
+	"encoding/json"
+	"github.com/Christoph-Raab/gardena-smart-system-exporter/pkg/gardena"
+	"github.com/Christoph-Raab/gardena-smart-system-exporter/pkg/gardena/device"
+	"os"
+	"testing"
+)
+
+func TestStoreDevicesFromState(t *testing.T) {
+	location, err := os.ReadFile("../../test/location.json")
+	if err != nil {
+		t.Fatal("Unable to read location.json file", err)
+	}
+	state := gardena.State{}
+	if err := json.Unmarshal(location, &state); err != nil {
+		t.Fatal("Unable to create state from json", err)
+	}
+	s := NewStore()
+	err = s.StoreDevices(state)
+	if err != nil {
+		t.Fatal("Unable to store state", err)
+	}
+
+	// Start testing the store
+	if len(s.devices) != 2 {
+		t.Fatalf("Excepted two devices, found %d", len(s.devices))
+	}
+
+	// Verify sensor
+	idOne := "dev-1-id"
+	sensor := s.devices[idOne]
+	id := sensor.GetDeviceId()
+	if id != idOne {
+		t.Fatalf("Excepted sensor to have id %s, got %s", idOne, id)
+	}
+	deviceType := sensor.GetDeviceType()
+	if deviceType != device.TypeSensor {
+		t.Fatalf("Expected device with id %s to be of type %s, got %s", idOne, device.TypeSensor, deviceType)
+	}
+	soH, err := sensor.GetFloatAttr(device.AttrSoilHumidity)
+	if err != nil {
+		t.Fatalf("Unexcepted error for attr %s:\n%v", device.AttrSoilHumidity, err)
+	}
+	if soH != 95 {
+		t.Fatalf("Excepted 95 as value for %s, got %v", device.AttrSoilHumidity, soH)
+	}
+	n, err := sensor.GetStrAttr(device.AttrName)
+	if err != nil {
+		t.Fatalf("Unexcepted error for attr %s:\n%v", device.AttrName, err)
+	}
+	if n != "Sensor01" {
+		t.Fatalf("Excepted Sensor01 as value for %s, got %v", device.AttrName, n)
+	}
+
+	// Verify mower
+	idTwo := "dev-2-id"
+	mower := s.devices[idTwo]
+	id = mower.GetDeviceId()
+	if id != idTwo {
+		t.Fatalf("Excepted mower to have id %s, got %s", idTwo, id)
+	}
+	deviceType = mower.GetDeviceType()
+	if deviceType != device.TypeMower {
+		t.Fatalf("Expected device with id %s to be of type %s, got %s", idTwo, device.TypeMower, deviceType)
+	}
+	opH, err := mower.GetFloatAttr(device.AttrOperatingHours)
+	if err != nil {
+		t.Fatalf("Unexcepted error for attr %s:\n%v", device.AttrOperatingHours, err)
+	}
+	if opH != 435 {
+		t.Fatalf("Excepted 435 as value for %s, got %v", device.AttrOperatingHours, soH)
+	}
+	n, err = mower.GetStrAttr(device.AttrName)
+	if err != nil {
+		t.Fatalf("Unexcepted error for attr %s:\n%v", device.AttrName, err)
+	}
+	if n != "SILENO" {
+		t.Fatalf("Excepted SILENO as value for %s, got %v", device.AttrName, n)
+	}
+
+	// Verify failure
+	str, err := mower.GetStrAttr("rand")
+	if str != "" || err == nil {
+		t.Fatalf("Expected empty value and error for str attribute with key 'rand'")
+	}
+	f, err := sensor.GetFloatAttr("foo")
+	if f != 0 || err == nil {
+		t.Fatalf("Expected empty value and error for float attribute with key 'foo'")
+	}
+}

--- a/pkg/gardena/device/common.go
+++ b/pkg/gardena/device/common.go
@@ -1,0 +1,103 @@
+package device
+
+import (
+	"fmt"
+	"reflect"
+)
+
+const (
+	CommonType       = "COMMON"
+	AttrType         = "type"
+	AttrId           = "id"
+	AttrName         = "name"
+	AttrBatteryLevel = "batteryLevel"
+	AttrBatteryState = "batteryState"
+	AttrRFLinkLevel  = "rfLinkLevel"
+	AttrSerial       = "serial"
+	AttrModelType    = "modelType"
+	AttrRFLinkState  = "rfLinkState"
+)
+
+type Common struct {
+	id           string
+	name         string
+	batteryLevel float64
+	batteryState string
+	rfLinkLevel  float64
+	serial       string
+	modelType    string
+	rfLinkState  string
+}
+
+func (c Common) getFloatAttr(key string) (float64, error) {
+	switch key {
+	case AttrBatteryLevel:
+		return c.batteryLevel, nil
+	case AttrRFLinkLevel:
+		return c.rfLinkLevel, nil
+	default:
+		return 0, fmt.Errorf("unsupported float attribute %s", key)
+	}
+}
+
+func (c Common) getStrAttr(key string) (string, error) {
+	switch key {
+	case AttrName:
+		return c.name, nil
+	case AttrBatteryState:
+		return c.batteryState, nil
+	case AttrSerial:
+		return c.serial, nil
+	case AttrModelType:
+		return c.modelType, nil
+	case AttrRFLinkState:
+		return c.rfLinkState, nil
+	default:
+		return "", fmt.Errorf("unsuppported string attribute %s", key)
+	}
+}
+
+func commonFrom(in map[string]any) (Common, error) {
+	var c Common
+	str, err := strFromVal(reflect.ValueOf(in[AttrId]))
+	if err != nil {
+		return Common{}, fmt.Errorf("unable to get attr '%s' from map %v, got err:\n%w", AttrId, in, err)
+	}
+	c.id = str
+	str, err = strFromVal(reflect.ValueOf(in[AttrName]))
+	if err != nil {
+		return Common{}, fmt.Errorf("unable to get attr '%s' from map %v, got err:\n%w", AttrName, in, err)
+	}
+	c.name = str
+	f, err := floatFromVal(reflect.ValueOf(in[AttrBatteryLevel]))
+	if err != nil {
+		return Common{}, fmt.Errorf("unable to get attr '%s' from map %v, got err:\n%w", AttrBatteryLevel, in, err)
+	}
+	c.batteryLevel = f
+	str, err = strFromVal(reflect.ValueOf(in[AttrBatteryState]))
+	if err != nil {
+		return Common{}, fmt.Errorf("unable to get attr '%s' from map %v, got err:\n%w", AttrBatteryState, in, err)
+	}
+	c.batteryState = str
+	f, err = floatFromVal(reflect.ValueOf(in[AttrRFLinkLevel]))
+	if err != nil {
+		return Common{}, fmt.Errorf("unable to get attr '%s' from map %v, got err:\n%w", AttrRFLinkLevel, in, err)
+	}
+	c.rfLinkLevel = f
+	str, err = strFromVal(reflect.ValueOf(in[AttrSerial]))
+	if err != nil {
+		return Common{}, fmt.Errorf("unable to get attr '%s' from map %v, got err:\n%w", AttrSerial, in, err)
+	}
+	c.serial = str
+	str, err = strFromVal(reflect.ValueOf(in[AttrModelType]))
+	if err != nil {
+		return Common{}, fmt.Errorf("unable to get attr '%s' from map %v, got err:\n%w", AttrModelType, in, err)
+	}
+	c.modelType = str
+	str, err = strFromVal(reflect.ValueOf(in[AttrRFLinkState]))
+	if err != nil {
+		return Common{}, fmt.Errorf("unable to get attr '%s' from map %v, got err:\n%w", AttrRFLinkState, in, err)
+	}
+	c.rfLinkState = str
+	return c, nil
+}

--- a/pkg/gardena/device/device.go
+++ b/pkg/gardena/device/device.go
@@ -1,0 +1,56 @@
+package device
+
+import (
+	"fmt"
+	"reflect"
+)
+
+const Type = "DEVICE"
+
+type Device interface {
+	GetDeviceId() string
+	GetDeviceType() string
+	GetFloatAttr(key string) (float64, error)
+	GetStrAttr(key string) (string, error)
+}
+
+// Factory create a gardena device from a given map of attributes. Currently supported
+// devices are:
+// - SENSOR
+// - MOWER
+func Factory(in map[string]any) (Device, error) {
+	switch in[AttrType] {
+	case TypeSensor:
+		s, err := SensorFrom(in)
+		if err != nil {
+			return nil, fmt.Errorf("unable to create sensor from %v, got err:\n%w", in, err)
+		}
+		return s, nil
+	case TypeMower:
+		m, err := MowerFrom(in)
+		if err != nil {
+			return nil, fmt.Errorf("unable to create mower from %v, got err:\n%w", in, err)
+		}
+		return m, nil
+	default:
+		return nil, fmt.Errorf("unsupported device type %s", in[AttrType])
+	}
+}
+
+// floatFromVal excepts a reflect.Value of kind Float64 and returns the float value
+// otherwise it returns an error
+func floatFromVal(in reflect.Value) (float64, error) {
+	if in.Kind() != reflect.Float64 {
+		return 0, fmt.Errorf("excepted float64 value, got %v", in)
+	}
+	return in.Float(), nil
+}
+
+// strFromVal excepts a reflect.Value of kind String and returns the string value
+// otherwise it returns an error
+func strFromVal(in reflect.Value) (string, error) {
+	if in.Kind() != reflect.String {
+		return "", fmt.Errorf("excepted string value, got %v", in)
+	}
+	return in.String(), nil
+}

--- a/pkg/gardena/device/mower.go
+++ b/pkg/gardena/device/mower.go
@@ -1,0 +1,77 @@
+package device
+
+import (
+	"fmt"
+	"reflect"
+)
+
+const (
+	TypeMower          = "MOWER"
+	AttrState          = "state"
+	AttrActivity       = "activity"
+	AttrOperatingHours = "operatingHours"
+)
+
+type Mower struct {
+	state          string
+	activity       string
+	operatingHours float64
+	common         Common
+}
+
+func (m Mower) GetDeviceId() string {
+	return m.common.id
+}
+
+func (m Mower) GetFloatAttr(key string) (float64, error) {
+	switch key {
+	case AttrOperatingHours:
+		return m.operatingHours, nil
+	default:
+		return m.common.getFloatAttr(key)
+	}
+}
+
+func (m Mower) GetStrAttr(key string) (string, error) {
+	switch key {
+	case AttrState:
+		return m.state, nil
+	case AttrActivity:
+		return m.activity, nil
+	default:
+		return m.common.getStrAttr(key)
+	}
+}
+
+func (m Mower) GetDeviceType() string {
+	return TypeMower
+}
+
+// MowerFrom creates a Mower af a map of attributes. Attribute values are excepted to be
+// interfaces that can be converted with th device.xFromVal methods.
+// If a value is of unexpected kind an error is returned.
+func MowerFrom(in map[string]any) (Mower, error) {
+	var m Mower
+	var f float64
+	str, err := strFromVal(reflect.ValueOf(in[AttrState]))
+	if err != nil {
+		return Mower{}, fmt.Errorf("unable to get attr '%s' from map %v, got err:\n%w", AttrState, in, err)
+	}
+	m.state = str
+	str, err = strFromVal(reflect.ValueOf(in[AttrActivity]))
+	if err != nil {
+		return Mower{}, fmt.Errorf("unable to get attr '%s' from map %v, got err:\n%w", AttrActivity, in, err)
+	}
+	m.activity = str
+	f, err = floatFromVal(reflect.ValueOf(in[AttrOperatingHours]))
+	if err != nil {
+		return Mower{}, fmt.Errorf("unable to get attr '%s' from map %v, got err:\n%w", AttrOperatingHours, in, err)
+	}
+	m.operatingHours = f
+	c, err := commonFrom(in)
+	if err != nil {
+		return Mower{}, fmt.Errorf("unable to generate common attributes, got err:\n%w", err)
+	}
+	m.common = c
+	return m, nil
+}

--- a/pkg/gardena/device/sensor.go
+++ b/pkg/gardena/device/sensor.go
@@ -1,0 +1,65 @@
+package device
+
+import (
+	"fmt"
+	"reflect"
+)
+
+const (
+	TypeSensor       = "SENSOR"
+	AttrSoilHumidity = "soilHumidity"
+	AttrSoilTemp     = "soilTemperature"
+)
+
+type Sensor struct {
+	soilHumidity    float64
+	soilTemperature float64
+	common          Common
+}
+
+func (s Sensor) GetDeviceId() string {
+	return s.common.id
+}
+
+func (s Sensor) GetFloatAttr(key string) (float64, error) {
+	switch key {
+	case AttrSoilHumidity:
+		return s.soilHumidity, nil
+	case AttrSoilTemp:
+		return s.soilTemperature, nil
+	default:
+		return s.common.getFloatAttr(key)
+	}
+}
+
+func (s Sensor) GetStrAttr(key string) (string, error) {
+	// has no string attributes itself
+	return s.common.getStrAttr(key)
+}
+
+func (s Sensor) GetDeviceType() string {
+	return TypeSensor
+}
+
+// SensorFrom creates a Sensor af a map of attributes. Attribute values are excepted to be
+// interfaces that can be converted with th device.xFromVal methods.
+// If a value is of unexpected kind an error is returned.
+func SensorFrom(in map[string]any) (Sensor, error) {
+	var s Sensor
+	f, err := floatFromVal(reflect.ValueOf(in[AttrSoilHumidity]))
+	if err != nil {
+		return Sensor{}, fmt.Errorf("unable to get attr '%s' from map %v, got err:\n%w", AttrSoilHumidity, in, err)
+	}
+	s.soilHumidity = f
+	f, err = floatFromVal(reflect.ValueOf(in[AttrSoilTemp]))
+	if err != nil {
+		return Sensor{}, fmt.Errorf("unable to get attr '%s' from map %v, got err:\n%w", AttrSoilTemp, in, err)
+	}
+	s.soilTemperature = f
+	c, err := commonFrom(in)
+	if err != nil {
+		return Sensor{}, fmt.Errorf("unable to generate common attributes, got err:\n%w", err)
+	}
+	s.common = c
+	return s, nil
+}

--- a/pkg/gardena/type.go
+++ b/pkg/gardena/type.go
@@ -4,16 +4,46 @@ const (
 	typeLocation = "LOCATION"
 )
 
-type LocationsFromApi struct {
+type Locations struct {
 	Data []struct {
-		LocationFromApi
+		Location
 	} `json:"data"`
 }
 
-type LocationFromApi struct {
+type Location struct {
 	Id         string `json:"id"`
 	Type       string `json:"type"`
 	Attributes struct {
-		Name string `json:"name"`
+		Attribute
 	} `json:"attributes"`
+}
+
+type Device struct {
+	Id           string               `json:"id"`
+	Type         string               `json:"type"`
+	Relationship string               `json:"relationship"`
+	Attributes   map[string]Attribute `json:"attributes"`
+}
+
+type Attribute struct {
+	Name  string
+	Value any
+}
+
+type State struct {
+	Data struct {
+		Id            string `json:"id"`
+		Type          string `json:"type"`
+		Relationships struct {
+			Devices struct {
+				Data []struct {
+					Device
+				} `json:"data"`
+			} `json:"devices"`
+		} `json:"relationships"`
+		Attributes struct {
+			Attribute
+		} `json:"attributes"`
+	} `json:"data"`
+	Included []Device `json:"included"`
 }

--- a/test/location.json
+++ b/test/location.json
@@ -1,0 +1,196 @@
+{
+  "data": {
+    "id": "location-1-id",
+    "type": "LOCATION",
+    "relationships": {
+      "devices": {
+        "data": [
+          {
+            "id": "dev-1-id",
+            "type": "DEVICE"
+          },
+          {
+            "id": "dev-2-id",
+            "type": "DEVICE"
+          }
+        ]
+      }
+    },
+    "attributes": {
+      "name": "GARDENA smart Garden"
+    }
+  },
+  "included": [
+    {
+      "id": "dev-1-id",
+      "type": "DEVICE",
+      "relationships": {
+        "location": {
+          "data": {
+            "id": "location-1-id",
+            "type": "LOCATION"
+          }
+        },
+        "services": {
+          "data": [
+            {
+              "id": "dev-1-id",
+              "type": "SENSOR"
+            },
+            {
+              "id": "dev-1-id",
+              "type": "COMMON"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "dev-2-id",
+      "type": "DEVICE",
+      "relationships": {
+        "location": {
+          "data": {
+            "id": "location-1-id",
+            "type": "LOCATION"
+          }
+        },
+        "services": {
+          "data": [
+            {
+              "id": "dev-2-id",
+              "type": "MOWER"
+            },
+            {
+              "id": "dev-2-id",
+              "type": "COMMON"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "dev-1-id",
+      "type": "SENSOR",
+      "relationships": {
+        "device": {
+          "data": {
+            "id": "dev-1-id",
+            "type": "DEVICE"
+          }
+        }
+      },
+      "attributes": {
+        "soilHumidity": {
+          "value": 95,
+          "timestamp": "2023-06-08T17:39:42.000+00:00"
+        },
+        "soilTemperature": {
+          "value": 24,
+          "timestamp": "2023-06-08T17:39:42.000+00:00"
+        }
+      }
+    },
+    {
+      "id": "dev-1-id",
+      "type": "COMMON",
+      "relationships": {
+        "device": {
+          "data": {
+            "id": "dev-1-id",
+            "type": "DEVICE"
+          }
+        }
+      },
+      "attributes": {
+        "name": {
+          "value": "Sensor01"
+        },
+        "batteryLevel": {
+          "value": 100,
+          "timestamp": "2023-06-08T17:39:49.000+00:00"
+        },
+        "batteryState": {
+          "value": "UNKNOWN",
+          "timestamp": "2023-06-08T17:39:49.000+00:00"
+        },
+        "rfLinkLevel": {
+          "value": 80,
+          "timestamp": "2023-06-08T17:39:42.000+00:00"
+        },
+        "serial": {
+          "value": "123456"
+        },
+        "modelType": {
+          "value": "GARDENA smart Sensor"
+        },
+        "rfLinkState": {
+          "value": "ONLINE"
+        }
+      }
+    },
+    {
+      "id": "dev-2-id",
+      "type": "MOWER",
+      "relationships": {
+        "device": {
+          "data": {
+            "id": "dev-2-id",
+            "type": "DEVICE"
+          }
+        }
+      },
+      "attributes": {
+        "state": {
+          "value": "OK",
+          "timestamp": "2023-06-08T17:34:01.000+00:00"
+        },
+        "activity": {
+          "value": "PARKED_TIMER",
+          "timestamp": "2023-06-08T17:34:01.000+00:00"
+        },
+        "operatingHours": {
+          "value": 435
+        }
+      }
+    },
+    {
+      "id": "dev-2-id",
+      "type": "COMMON",
+      "relationships": {
+        "device": {
+          "data": {
+            "id": "dev-2-id",
+            "type": "DEVICE"
+          }
+        }
+      },
+      "attributes": {
+        "name": {
+          "value": "SILENO"
+        },
+        "batteryLevel": {
+          "value": 100,
+          "timestamp": "2023-06-08T17:34:01.000+00:00"
+        },
+        "batteryState": {
+          "value": "OK",
+          "timestamp": "2023-06-08T18:22:54.726+00:00"
+        },
+        "rfLinkLevel": {
+          "value": 100,
+          "timestamp": "2023-06-08T18:00:10.000+00:00"
+        },
+        "serial": {
+          "value": "54321"
+        },
+        "modelType": {
+          "value": "GARDENA smart Mower"
+        },
+        "rfLinkState": {
+          "value": "ONLINE"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Fetch all data of all locations and puts the found devices into an internal state.

The internal state can later be used to:
- reflect updates of the device (streamed via WebSocket)
- create/update metrics for each device

Resolves https://github.com/Christoph-Raab/gardena-smart-system-exporter/issues/8